### PR TITLE
Add validation for empty Vault address

### DIFF
--- a/src/integrationTest/java/com/snc/discovery/integration/CredentialResolverTest.java
+++ b/src/integrationTest/java/com/snc/discovery/integration/CredentialResolverTest.java
@@ -190,13 +190,13 @@ public class CredentialResolverTest {
     private static HashMap<String, String> properties(String address, String ca, Boolean skipTLS) {
         HashMap<String, String> props = new HashMap<>();
         if (address != null) {
-            props.put("mid.external_credentials.vault.address", address);
+            props.put(CredentialResolver.PROP_ADDRESS, address);
         }
         if (ca != null) {
-            props.put("mid.external_credentials.vault.ca", ca);
+            props.put(CredentialResolver.PROP_CA, ca);
         }
         if (skipTLS != null) {
-            props.put("mid.external_credentials.vault.tls_skip_verify", skipTLS.toString());
+            props.put(CredentialResolver.PROP_TLS_SKIP_VERIFY, skipTLS.toString());
         }
 
         return props;

--- a/src/main/java/com/snc/discovery/CredentialResolver.java
+++ b/src/main/java/com/snc/discovery/CredentialResolver.java
@@ -44,15 +44,23 @@ public class CredentialResolver {
     public static final String VAL_PASSPHRASE = "passphrase"; // the string pass phrase for the credential
     public static final String VAL_PKEY = "pkey"; // the string private key for the credential
 
+    public static final String PROP_ADDRESS = "mid.external_credentials.vault.address"; // The address of Vault Agent, as resolvable from the MID server
+    public static final String PROP_CA = "mid.external_credentials.vault.ca"; // The custom CA to trust in PEM format
+    public static final String PROP_TLS_SKIP_VERIFY = "mid.external_credentials.vault.tls_skip_verify"; // Whether to skip TLS verification
+
     /**
      * Resolve a credential.
      */
     public Map resolve(Map args) throws IOException {
-        String vaultAddress = getProperty.apply("mid.external_credentials.vault.address");
-        String vaultCA = getProperty.apply("mid.external_credentials.vault.ca");
-        String tlsSkipVerifyRaw = getProperty.apply("mid.external_credentials.vault.tls_skip_verify");
+        String vaultAddress = getProperty.apply(PROP_ADDRESS);
+        String vaultCA = getProperty.apply(PROP_CA);
+        String tlsSkipVerifyRaw = getProperty.apply(PROP_TLS_SKIP_VERIFY);
 
-        Boolean tlsSkipVerify = false;
+        if (vaultAddress == null || vaultAddress.equals("")) {
+            throw new RuntimeException(String.format("MID server property %s is empty but required", PROP_ADDRESS));
+        }
+
+        boolean tlsSkipVerify = false;
         if (tlsSkipVerifyRaw != null && !tlsSkipVerifyRaw.equals("")) {
             tlsSkipVerify = Boolean.parseBoolean(tlsSkipVerifyRaw);
         }

--- a/src/main/java/com/snc/discovery/TLSConfig.java
+++ b/src/main/java/com/snc/discovery/TLSConfig.java
@@ -1,10 +1,11 @@
 package com.snc.discovery;
 
-import java.io.BufferedReader;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
@@ -14,8 +15,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.util.Objects;
-import javax.net.ssl.*;
 
 /**
  * <p>A container for SSL-related configuration options, meant to be stored within a {@link CredentialResolver} instance.</p>
@@ -75,7 +74,7 @@ public class TLSConfig implements Serializable {
      * @param verify Whether or not to verify the SSL certificate used by Vault with HTTPS connections.  Default is <code>true</code>.
      * @return This object, with verify populated, ready for additional builder-pattern method calls or else finalization with the build() method
      */
-    public TLSConfig verify(final Boolean verify) {
+    public TLSConfig verify(final boolean verify) {
         this.verifyObject = verify;
         return this;
     }


### PR DESCRIPTION
Prior to this, not setting the Vault address property would trigger a `org.apache.http.client.ClientProtocolException` exception due to an empty host, which is much harder to debug as a user.