### PR TITLE
Fix sl4j warning from tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,8 +100,6 @@ val integrationTestRuntimeOnly by configurations.getting {
 	extendsFrom(configurations.runtimeOnly.get())
 }
 
-configurations["integrationTestRuntimeOnly"].extendsFrom(configurations.runtimeOnly.get())
-
 dependencies {
 	integrationTestImplementation("junit:junit:4.13.2")
 	integrationTestImplementation("org.testcontainers:testcontainers:1.15.3")


### PR DESCRIPTION
Specify a noop sl4j runtime dependency for tests. Before this update, running the tests resulted in this warning getting printed to stderr:

```
com.snc.discovery.integration.CredentialResolverTest STANDARD_ERROR
    SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
    SLF4J: Defaulting to no-operation (NOP) logger implementation
    SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
    SLF4J: Failed to load class "org.slf4j.impl.StaticMDCBinder".
    SLF4J: Defaulting to no-operation MDCAdapter implementation.
    SLF4J: See http://www.slf4j.org/codes.html#no_static_mdc_binder for further details.
```