### PR TITLE
Update to use CRT prepare workflow

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -12,7 +12,7 @@ project "vault-servicenow-credential-resolver" {
   github {
     organization = "hashicorp"
     repository = "vault-servicenow-credential-resolver"
-    release_branches = ["main"]
+    release_branches = ["main", "update-crt-prepare"]
   }
 }
 

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -12,7 +12,7 @@ project "vault-servicenow-credential-resolver" {
   github {
     organization = "hashicorp"
     repository = "vault-servicenow-credential-resolver"
-    release_branches = ["main", "update-crt-prepare"]
+    release_branches = ["main"]
   }
 }
 

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -30,53 +30,13 @@ event "build" {
   }
 }
 
-event "upload-dev" {
+event "prepare" {
   depends = ["build"]
-  action "upload-dev" {
+  action "prepare" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "upload-dev"
-    depends = ["build"]
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "security-scan-binaries" {
-  depends = ["upload-dev"]
-  action "security-scan-binaries" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "security-scan-binaries"
-    config = "security-scan.hcl"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "sign" {
-  depends = ["security-scan-binaries"]
-  action "sign" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "sign"
-  }
-
-  notification {
-    on = "fail"
-  }
-}
-
-event "verify" {
-  depends = ["sign"]
-  action "verify" {
-    organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "verify"
+    repository   = "crt-workflows-common"
+    workflow     = "prepare"
+    depends      = ["build"]
   }
 
   notification {


### PR DESCRIPTION
This update, moves vault-servicenow-credential-resolver to use the prepare workflow. This workflow encapsulates several previous workflows, running jobs in parallel to reduce the artifact processing time. See [here](https://hashicorp.atlassian.net/wiki/spaces/RELENG/pages/2489712686/Dec+7th+2022+-+Introducing+the+new+Prepare+workflow) for more info.