### PR TITLE
PR to support for bearer token and ssh certificates as credential types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
     steps:
       - name: 'Checkout directory'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2      - name: Generate metadata file
+      - name: Generate metadata file
         id: generate-metadata-file
         uses: hashicorp/actions-generate-metadata@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
       - name: 'Checkout directory'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2      - name: Generate metadata file
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Generate metadata file
         id: generate-metadata-file
         uses: hashicorp/actions-generate-metadata@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,8 @@ jobs:
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: get product version
         id: get-product-version
         run: |
@@ -33,15 +34,14 @@ jobs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
       - name: 'Checkout directory'
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - name: Generate metadata file
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2      - name: Generate metadata file
         id: generate-metadata-file
         uses: hashicorp/actions-generate-metadata@v1
         with:
           version: ${{ needs.get-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}
 
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
@@ -53,8 +53,8 @@ jobs:
     name: Build Jar
 
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Build
         id: build-binary
         env:
@@ -67,7 +67,7 @@ jobs:
           echo "path=${ZIP_FILE}" >> $GITHUB_OUTPUT
           echo "name=$(basename ${ZIP_FILE})" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ steps.build-binary.outputs.name }}
           path: ${{ steps.build-binary.outputs.path }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: "Test"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Test
         run: ./gradlew test
       - name: Integration test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     name: "Test"
     runs-on: ubuntu-latest
     steps:
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Test
         run: ./gradlew test
       - name: Integration test

--- a/src/main/java/com/snc/discovery/CredentialResolver.java
+++ b/src/main/java/com/snc/discovery/CredentialResolver.java
@@ -310,7 +310,7 @@ public class CredentialResolver {
         jdbc                                (new String[]{VAL_USER, VAL_PSWD}),
         jms                                 (new String[]{VAL_USER, VAL_PSWD}),
         aws                                 (new String[]{VAL_USER, VAL_PSWD}),
-        ssh_private_key                     (new String[]{VAL_USER, VAL_PKEY, VAL_SSHCERT}),
+        ssh_private_key                     (new String[]{VAL_USER, VAL_PKEY}),
         sn_cfg_ansible                      (new String[]{VAL_USER, VAL_PKEY}),
         sn_disco_certmgmt_certificate_ca    (new String[]{VAL_USER, VAL_PKEY}),
         cfg_chef_credentials                (new String[]{VAL_USER, VAL_PKEY}),

--- a/src/main/java/com/snc/discovery/CredentialResolver.java
+++ b/src/main/java/com/snc/discovery/CredentialResolver.java
@@ -66,7 +66,7 @@ public class CredentialResolver {
     public static final String VAL_PRIVPROTO = "privprotocol"; // the string privacy protocol for the credential
     public static final String VAL_PRIVKEY = "privkey"; // the string privacy key for the credential
     public static final String VAL_CONTEXTNAME = "contextname"; // the string context name for the credential
-    public static final String VAL_BEARER = "bearer_token"; // the string brearer token for the credential
+    public static final String VAL_BEARER = "bearer_token"; // the string bearer token for the credential
     public static final String PROP_ADDRESS = "mid.external_credentials.vault.address"; // The address of Vault Agent, as resolvable from the MID server
     public static final String PROP_CA = "mid.external_credentials.vault.ca"; // The custom CA to trust in PEM format
     public static final String PROP_TLS_SKIP_VERIFY = "mid.external_credentials.vault.tls_skip_verify"; // Whether to skip TLS verification
@@ -225,7 +225,7 @@ public class CredentialResolver {
         ValueAndSource bearer = valueAndSourceFromData(data, "bearer_token");
         ValueAndSource contextname = valueAndSourceFromData(data, "contextname");
 
-        System.err.printf("Setting values from fields %s=%s, %s=%s,  %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s%n",    
+        System.err.printf("Setting values from fields %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s%n",
                 VAL_USER, username.source,
                 VAL_PSWD, password.source,
                 VAL_PKEY, privateKey.source,

--- a/src/main/java/com/snc/discovery/CredentialResolver.java
+++ b/src/main/java/com/snc/discovery/CredentialResolver.java
@@ -28,6 +28,7 @@ import java.util.function.Function;
 public class CredentialResolver {
     private static final CloseableHttpClient defaultHTTPClient = HttpClients.createDefault();
     private static final Gson gson = new Gson();
+    private static final String SSH_CERT_ISSUE_PATH = "/issue/";
     private final Function<String, String> getProperty;
 
     public CredentialResolver() {
@@ -65,7 +66,7 @@ public class CredentialResolver {
     public static final String VAL_PRIVPROTO = "privprotocol"; // the string privacy protocol for the credential
     public static final String VAL_PRIVKEY = "privkey"; // the string privacy key for the credential
     public static final String VAL_CONTEXTNAME = "contextname"; // the string context name for the credential
-
+    public static final String VAL_BEARER = "bearer_token"; // the string brearer token for the credential
     public static final String PROP_ADDRESS = "mid.external_credentials.vault.address"; // The address of Vault Agent, as resolvable from the MID server
     public static final String PROP_CA = "mid.external_credentials.vault.ca"; // The custom CA to trust in PEM format
     public static final String PROP_TLS_SKIP_VERIFY = "mid.external_credentials.vault.tls_skip_verify"; // Whether to skip TLS verification
@@ -94,7 +95,7 @@ public class CredentialResolver {
 
         Map<String, String> result = extractKeys(body);
         // Hack to allow configuration of the principal for ssh-certificates within ServiceNow
-        if (id.contains("/issue/")) {
+        if (id.contains(SSH_CERT_ISSUE_PATH)) {
             try {
                 List<NameValuePair> params = URLEncodedUtils.parse(new URI(id), StandardCharsets.UTF_8);
                 for (NameValuePair param : params) {
@@ -113,7 +114,7 @@ public class CredentialResolver {
     }
 
     private HttpRequestBase buildRequestBase(String id, String vaultAddress) {
-        if (id.contains("/issue/")) {
+        if (id.contains(SSH_CERT_ISSUE_PATH)) {
             HttpEntityEnclosingRequestBase post = new HttpPost(vaultAddress + "/v1/" + id);
             post.setEntity(new StringEntity("{}", "UTF-8"));
             return post;
@@ -221,9 +222,10 @@ public class CredentialResolver {
         ValueAndSource authkey = valueAndSourceFromData(data, "authkey");
         ValueAndSource privprotocol = valueAndSourceFromData(data, "privprotocol");
         ValueAndSource privkey = valueAndSourceFromData(data, "privkey");
+        ValueAndSource bearer = valueAndSourceFromData(data, "bearer_token");
         ValueAndSource contextname = valueAndSourceFromData(data, "contextname");
 
-        System.err.printf("Setting values from fields %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s%n",    
+        System.err.printf("Setting values from fields %s=%s, %s=%s,  %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s%n",    
                 VAL_USER, username.source,
                 VAL_PSWD, password.source,
                 VAL_PKEY, privateKey.source,
@@ -233,6 +235,7 @@ public class CredentialResolver {
                 VAL_AUTHKEY, authkey.source,
                 VAL_PRIVPROTO, privprotocol.source,
                 VAL_PRIVKEY, privkey.source,
+                VAL_BEARER, bearer.source,
                 VAL_CONTEXTNAME, contextname.source);
 
         HashMap<String, String> result = new HashMap<>();
@@ -262,6 +265,9 @@ public class CredentialResolver {
         }
         if (privkey.value != null) {
             result.put(VAL_PRIVKEY, privkey.value);
+        }
+        if (bearer.value != null) {
+            result.put(VAL_BEARER, bearer.value);
         }
         if (contextname.value != null) {
             result.put(VAL_CONTEXTNAME, contextname.value);
@@ -310,7 +316,8 @@ public class CredentialResolver {
         cfg_chef_credentials                (new String[]{VAL_USER, VAL_PKEY}),
         infoblox                            (new String[]{VAL_USER, VAL_PKEY}),
         api_key                             (new String[]{VAL_USER, VAL_PKEY}),
-        snmpv3                              (new String[]{VAL_USER, VAL_AUTHPROTO, VAL_AUTHKEY, VAL_PRIVPROTO, VAL_PRIVKEY, VAL_CONTEXTNAME});
+        snmpv3                              (new String[]{VAL_USER, VAL_AUTHPROTO, VAL_AUTHKEY, VAL_PRIVPROTO, VAL_PRIVKEY, VAL_CONTEXTNAME}),
+        bearer                              (new String[]{VAL_BEARER});
         private final String[] expectedFields;
 
         CredentialType(String[] expectedFields) {

--- a/src/main/java/com/snc/discovery/CredentialResolver.java
+++ b/src/main/java/com/snc/discovery/CredentialResolver.java
@@ -8,25 +8,41 @@ package com.snc.discovery;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import org.apache.http.client.HttpResponseException;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpUriRequest;
+import com.service_now.mid.services.Config;
+import org.apache.http.NameValuePair;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-
+import org.apache.http.client.methods.*;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.entity.StringEntity;
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Scanner;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 import java.util.function.Function;
 
 public class CredentialResolver {
     private static final CloseableHttpClient defaultHTTPClient = HttpClients.createDefault();
     private static final Gson gson = new Gson();
     private final Function<String, String> getProperty;
+
+    public CredentialResolver() {
+        getProperty = prop -> {
+            try {
+                // Use reflection to avoid IConfig interface resolution issue at compile time
+                Method getMethod = Config.class.getMethod("get");
+                Object config = getMethod.invoke(null);
+                Method getPropertyMethod = config.getClass().getMethod("getProperty", String.class);
+                return (String) getPropertyMethod.invoke(config, prop);
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to get property: " + prop, e);
+            }
+        };
+    }
 
     public CredentialResolver(Function<String, String> getProperty) {
         this.getProperty = getProperty;
@@ -43,6 +59,7 @@ public class CredentialResolver {
     public static final String VAL_PSWD = "pswd"; // the string password for the credential
     public static final String VAL_PASSPHRASE = "passphrase"; // the string pass phrase for the credential
     public static final String VAL_PKEY = "pkey"; // the string private key for the credential
+    public static final String VAL_SSHCERT = "sshcert"; // the string signed SSH-certificate for the credential
     public static final String VAL_AUTHPROTO = "authprotocol"; // the string authentication protocol for the credential
     public static final String VAL_AUTHKEY = "authkey"; // the string authentication key for the credential
     public static final String VAL_PRIVPROTO = "privprotocol"; // the string privacy protocol for the credential
@@ -72,13 +89,37 @@ public class CredentialResolver {
 
         String id = (String) args.get(ARG_ID);
 
-        String body = send(new HttpGet(vaultAddress + "/v1/" + id), vaultCA, tlsSkipVerify);
+        String body = send(buildRequestBase(id, vaultAddress), vaultCA, tlsSkipVerify);
         System.err.println("Successfully queried Vault for credential id: "+id);
 
         Map<String, String> result = extractKeys(body);
+        // Hack to allow configuration of the principal for ssh-certificates within ServiceNow
+        if (id.contains("/issue/")) {
+            try {
+                List<NameValuePair> params = URLEncodedUtils.parse(new URI(id), StandardCharsets.UTF_8);
+                for (NameValuePair param : params) {
+                    if (param.getName().equals("user")) {
+                        result.put(VAL_USER, param.getValue());
+                    }
+                }
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
         CredentialType type = lookupByName((String) args.get(ARG_TYPE));
         validateResult(result, type);
         return result;
+    }
+
+    private HttpRequestBase buildRequestBase(String id, String vaultAddress) {
+        if (id.contains("/issue/")) {
+            HttpEntityEnclosingRequestBase post = new HttpPost(vaultAddress + "/v1/" + id);
+            post.setEntity(new StringEntity("{}", "UTF-8"));
+            return post;
+        }
+
+        return new HttpGet(vaultAddress + "/v1/" + id);
     }
 
     /**
@@ -175,19 +216,20 @@ public class CredentialResolver {
         ValueAndSource password = valueAndSourceFromData(data, "secret_key", "current_password", "password");
         ValueAndSource privateKey = valueAndSourceFromData(data, "private_key");
         ValueAndSource passphrase = valueAndSourceFromData(data, "passphrase");
-
+        ValueAndSource sshCertificate = valueAndSourceFromData(data, "signed_key");
         ValueAndSource authprotocol = valueAndSourceFromData(data, "authprotocol");
         ValueAndSource authkey = valueAndSourceFromData(data, "authkey");
         ValueAndSource privprotocol = valueAndSourceFromData(data, "privprotocol");
         ValueAndSource privkey = valueAndSourceFromData(data, "privkey");
         ValueAndSource contextname = valueAndSourceFromData(data, "contextname");
 
-        System.err.printf("Setting values from fields %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s%n",
+        System.err.printf("Setting values from fields %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s, %s=%s%n",    
                 VAL_USER, username.source,
                 VAL_PSWD, password.source,
                 VAL_PKEY, privateKey.source,
                 VAL_PASSPHRASE, passphrase.source,
                 VAL_AUTHPROTO, authprotocol.source,
+                VAL_SSHCERT, sshCertificate.source,
                 VAL_AUTHKEY, authkey.source,
                 VAL_PRIVPROTO, privprotocol.source,
                 VAL_PRIVKEY, privkey.source,
@@ -202,6 +244,9 @@ public class CredentialResolver {
         }
         if (privateKey.value != null) {
             result.put(VAL_PKEY, privateKey.value);
+        }
+        if (sshCertificate.value != null) {
+            result.put(VAL_SSHCERT, sshCertificate.value);
         }
         if (passphrase.value != null) {
             result.put(VAL_PASSPHRASE, passphrase.value);
@@ -259,7 +304,7 @@ public class CredentialResolver {
         jdbc                                (new String[]{VAL_USER, VAL_PSWD}),
         jms                                 (new String[]{VAL_USER, VAL_PSWD}),
         aws                                 (new String[]{VAL_USER, VAL_PSWD}),
-        ssh_private_key                     (new String[]{VAL_USER, VAL_PKEY}),
+        ssh_private_key                     (new String[]{VAL_USER, VAL_PKEY, VAL_SSHCERT}),
         sn_cfg_ansible                      (new String[]{VAL_USER, VAL_PKEY}),
         sn_disco_certmgmt_certificate_ca    (new String[]{VAL_USER, VAL_PKEY}),
         cfg_chef_credentials                (new String[]{VAL_USER, VAL_PKEY}),

--- a/src/test/java/com/snc/discovery/CredentialResolverTest.java
+++ b/src/test/java/com/snc/discovery/CredentialResolverTest.java
@@ -125,6 +125,14 @@ public class CredentialResolverTest {
     }
 
     @Test
+    public void testResolveBearerTokenFields() throws IOException {
+        Map result = setupAndResolve("kv/bearer_token", "{'data':{'bearer_token':'the-bearertoken'}}");
+
+	Assert.assertEquals("the-bearertoken", result.get(CredentialResolver.VAL_BEARER));
+        Assert.assertEquals(1, result.size());
+    }
+
+    @Test
     public void testResolveAwsFields() throws IOException {
         Map result = setupAndResolve("aws/aws-user", "{'data':{'username':'aws-user','password':'aws-password','current_password':'aws-current-password','access_key':'aws-access-key','secret_key':'aws-secret-key'}}");
 
@@ -171,6 +179,7 @@ public class CredentialResolverTest {
         input.put(CredentialResolver.VAL_AUTHKEY, "");
         input.put(CredentialResolver.VAL_PRIVPROTO, "");
         input.put(CredentialResolver.VAL_PRIVKEY, "");
+        input.put(CredentialResolver.VAL_BEARER, "");
         for (CredentialResolver.CredentialType type : CredentialResolver.CredentialType.values()) {
             // No validation errors expected
             cr.validateResult(input, type);

--- a/src/test/java/com/snc/discovery/CredentialResolverTest.java
+++ b/src/test/java/com/snc/discovery/CredentialResolverTest.java
@@ -33,6 +33,19 @@ public class CredentialResolverTest {
         return cr.resolve(input);
     }
 
+    private Map setupAndResolvePostRequest(String path, String requestJson, String json) throws IOException {
+        stubFor(post("/v1/" + path)
+            .withHeader("accept", containing("application/json"))
+            .withRequestBody(equalToJson(requestJson))
+            .willReturn(ok()
+                .withHeader("Content-Type", "application/json")
+                .withBody(json)));
+
+        CredentialResolver cr = new CredentialResolver(CredentialResolverTest::testProperty);
+        HashMap<String, String> input = new HashMap<>();
+        input.put(CredentialResolver.ARG_ID, path);
+        return cr.resolve(input);
+    }
     private static String testProperty(String p) {
         HashMap<String, String> properties = new HashMap<>();
         properties.put(CredentialResolver.PROP_ADDRESS, "http://localhost:8080");
@@ -70,6 +83,16 @@ public class CredentialResolverTest {
         Assert.assertEquals("ssh-user", result.get(CredentialResolver.VAL_USER));
         Assert.assertEquals("my_very_private_key", result.get(CredentialResolver.VAL_PKEY));
         Assert.assertEquals(2, result.size());
+    }
+
+    @Test
+    public void testResolveSshEngine() throws IOException {
+        Map result = setupAndResolvePostRequest("mount-path/issue/role-name?user=ssh-user", "{}", "{'data':{'signed_key':'my_signed_public_key','private_key':'my_very_private_key'}}");
+
+        Assert.assertEquals("ssh-user", result.get(CredentialResolver.VAL_USER));
+        Assert.assertEquals("my_signed_public_key", result.get(CredentialResolver.VAL_SSHCERT));
+        Assert.assertEquals("my_very_private_key", result.get(CredentialResolver.VAL_PKEY));
+        Assert.assertEquals(3, result.size());
     }
 
     @Test
@@ -142,6 +165,7 @@ public class CredentialResolverTest {
         input.put(CredentialResolver.VAL_USER, "");
         input.put(CredentialResolver.VAL_PSWD, "");
         input.put(CredentialResolver.VAL_PKEY, "");
+        input.put(CredentialResolver.VAL_SSHCERT, "");
         input.put(CredentialResolver.VAL_PASSPHRASE, "");
         input.put(CredentialResolver.VAL_AUTHPROTO, "");
         input.put(CredentialResolver.VAL_AUTHKEY, "");


### PR DESCRIPTION
#This PR is addressing 

- the github action issues from the PR -https://github.com/hashicorp/vault-servicenow-credential-resolver/pull/33 regarding issue  -  https://hashicorp.atlassian.net/browse/VAULT-29563
- https://hashicorp.atlassian.net/browse/VAULT-37635 - adding ssh certificates to credential type
- https://hashicorp.atlassian.net/browse/VAULT-23958- adding bearer token type as credential type

## Tests passed.
unit test and integrations tests.
<img width="1163" height="471" alt="image" src="https://github.com/user-attachments/assets/eb516974-c24c-4898-ab7a-7a07c8399d27" />

### local ServiceNow acceptance testing pending as I have to get ServiceNow instance created, vault agent configured and MID-server installed... creating PR to review and get feedback meanwhile...


