### PR TITLE
removing go binary related modules

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -2,9 +2,8 @@
 # SPDX-License-Identifier: MPL-2.0
 
 binary {
-	secrets      = true
-	go_modules   = false
-	osv          = true
-	oss_index    = false
-	nvd          = false
+	nvd          = true
+    secrets {
+        all = true
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,10 +3,16 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFiles
+import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.gradle.process.ExecOperations
 
 import java.io.ByteArrayOutputStream
+import javax.inject.Inject
 
 plugins {
 	// https://docs.gradle.org/current/userguide/java_plugin.html#java_plugin
@@ -38,11 +44,14 @@ sourceSets {
 }
 
 // Copy mid jars for build
-tasks.register("copyMidJars") {
-	group = "build"
-	description = "Copy MID Jars from docker image"
+abstract class CopyMidJars @Inject constructor(private val execOps: ExecOperations) : DefaultTask() {
+	@get:Input
 	val srcDir = "/opt/agent/lib"
+
+	@get:Input
 	val destDir = "build/mid"
+
+	@get:Input
 	val jars = listOf(
         "commons-core-automation.jar",
         "commons-glide.jar",
@@ -50,24 +59,25 @@ tasks.register("copyMidJars") {
         "mid.jar",
         "snc-automation-api.jar",
     )
-	outputs.files(jars.map { "${destDir}/${it}" })
 
-	// Code inside doLast will only run if Gradle decides the task needs running,
-	// e.g. if the Jars are not already in place.
-	doLast {
+	@get:OutputFiles
+	val outputFiles = jars.map { File("${destDir}/${it}") }
+
+	@TaskAction
+	fun copyJars() {
 		println("Copying MID Jars")
 		val output = ByteArrayOutputStream()
-		exec {
+		execOps.exec {
 			commandLine("docker", "create", "moers/mid-server:${System.getenv("MID_SERVER_VERSION") ?: "washingtondc.08-31-2024_1809"}")
 			standardOutput = output
 		}
 		val id = output.toString().trim()
 		for (jar in jars) {
-			exec {
+			execOps.exec {
 				commandLine("docker", "cp", "${id}:${srcDir}/${jar}", destDir)
 			}
 		}
-		exec {
+		execOps.exec {
 			commandLine("docker", "rm", "-v", id)
 			// Suppress output from docker rm
 			standardOutput = output
@@ -75,9 +85,14 @@ tasks.register("copyMidJars") {
 	}
 }
 
+tasks.register<CopyMidJars>("copyMidJars") {
+	group = "build"
+	description = "Copy MID Jars from docker image"
+}
+
 dependencies {
-	implementation("com.google.code.gson:gson:2.8.8")
-	implementation("org.apache.httpcomponents:httpclient:4.5.13")
+	implementation("com.google.code.gson:gson:2.13.2")
+	implementation("org.apache.httpcomponents.client5:httpclient5:5.6")
 
 	// lib/ folder requires mid.jar and commons-glide.jar to build
 	implementation(fileTree("build/mid") {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jul 11 16:09:05 EDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/integrationTest/java/com/snc/discovery/integration/CredentialResolverTest.java
+++ b/src/integrationTest/java/com/snc/discovery/integration/CredentialResolverTest.java
@@ -9,6 +9,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.snc.discovery.CredentialResolver;
 import okhttp3.tls.HeldCertificate;
+import org.apache.hc.client5.http.HttpResponseException;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPut;
 import org.apache.hc.core5.http.io.entity.StringEntity;
@@ -110,8 +111,8 @@ public class CredentialResolverTest {
         CredentialResolver cr = new CredentialResolver(properties(vault.getAddress(), null, null)::get);
         HashMap<String, String> input = new HashMap<>();
         input.put(CredentialResolver.ARG_ID, "secret/data/ssh");
-        IOException e = assertThrows(IOException.class, () -> cr.resolve(input));
-        assertErrorContains(e, "403");
+        HttpResponseException e = assertThrows(HttpResponseException.class, () -> cr.resolve(input));
+        assertErrorContains(e, "permission denied");
     }
 
     @Test
@@ -119,7 +120,7 @@ public class CredentialResolverTest {
         CredentialResolver cr = new CredentialResolver(properties(agent.getAddress(), null, null)::get);
         HashMap<String, String> input = new HashMap<>();
         input.put(CredentialResolver.ARG_ID, "secret/data/not-there");
-        IOException e = assertThrows(IOException.class, () -> cr.resolve(input));
+        HttpResponseException e = assertThrows(HttpResponseException.class, () -> cr.resolve(input));
         assertErrorContains(e, "404");
     }
 
@@ -128,8 +129,8 @@ public class CredentialResolverTest {
         CredentialResolver cr = new CredentialResolver(properties(agent.getAddress(), null, null)::get);
         HashMap<String, String> input = new HashMap<>();
         input.put(CredentialResolver.ARG_ID, "secret/bad-path");
-        IOException e = assertThrows(IOException.class, () -> cr.resolve(input));
-        assertErrorContains(e, "404.*warnings.*invalid path");
+        HttpResponseException e = assertThrows(HttpResponseException.class, () -> cr.resolve(input));
+        assertErrorContains(e, "Invalid path");
     }
 
     @Test

--- a/src/integrationTest/java/com/snc/discovery/integration/CredentialResolverTest.java
+++ b/src/integrationTest/java/com/snc/discovery/integration/CredentialResolverTest.java
@@ -9,10 +9,9 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.snc.discovery.CredentialResolver;
 import okhttp3.tls.HeldCertificate;
-import org.apache.http.client.HttpResponseException;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.entity.StringEntity;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -26,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Scanner;
@@ -110,8 +110,8 @@ public class CredentialResolverTest {
         CredentialResolver cr = new CredentialResolver(properties(vault.getAddress(), null, null)::get);
         HashMap<String, String> input = new HashMap<>();
         input.put(CredentialResolver.ARG_ID, "secret/data/ssh");
-        HttpResponseException e = assertThrows(HttpResponseException.class, () -> cr.resolve(input));
-        assertErrorContains(e, "status code: 403.+");
+        IOException e = assertThrows(IOException.class, () -> cr.resolve(input));
+        assertErrorContains(e, "403");
     }
 
     @Test
@@ -119,7 +119,7 @@ public class CredentialResolverTest {
         CredentialResolver cr = new CredentialResolver(properties(agent.getAddress(), null, null)::get);
         HashMap<String, String> input = new HashMap<>();
         input.put(CredentialResolver.ARG_ID, "secret/data/not-there");
-        HttpResponseException e = assertThrows(HttpResponseException.class, () -> cr.resolve(input));
+        IOException e = assertThrows(IOException.class, () -> cr.resolve(input));
         assertErrorContains(e, "404");
     }
 
@@ -128,7 +128,7 @@ public class CredentialResolverTest {
         CredentialResolver cr = new CredentialResolver(properties(agent.getAddress(), null, null)::get);
         HashMap<String, String> input = new HashMap<>();
         input.put(CredentialResolver.ARG_ID, "secret/bad-path");
-        HttpResponseException e = assertThrows(HttpResponseException.class, () -> cr.resolve(input));
+        IOException e = assertThrows(IOException.class, () -> cr.resolve(input));
         assertErrorContains(e, "404.*warnings.*invalid path");
     }
 
@@ -176,7 +176,7 @@ public class CredentialResolverTest {
     private static JsonObject put(String path, String data) throws IOException {
         HttpPut put = new HttpPut(url(path));
         if (data != null) {
-            put.setEntity(new StringEntity(data));
+            put.setEntity(new StringEntity(data, StandardCharsets.UTF_8));
         }
         put.setHeader("X-Vault-Token", "root");
         return gson.fromJson(CredentialResolver.send(put, "", false), JsonObject.class);

--- a/src/main/java/com/snc/discovery/CredentialResolver.java
+++ b/src/main/java/com/snc/discovery/CredentialResolver.java
@@ -7,15 +7,19 @@ package com.snc.discovery;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import org.apache.http.client.HttpResponseException;
 import com.service_now.mid.services.Config;
-import org.apache.http.NameValuePair;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.client.methods.*;
-import org.apache.http.client.utils.URLEncodedUtils;
-import org.apache.http.entity.StringEntity;
+import org.apache.hc.client5.http.classic.methods.*;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.net.URIBuilder;
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -97,7 +101,8 @@ public class CredentialResolver {
         // Hack to allow configuration of the principal for ssh-certificates within ServiceNow
         if (id.contains(SSH_CERT_ISSUE_PATH)) {
             try {
-                List<NameValuePair> params = URLEncodedUtils.parse(new URI(id), StandardCharsets.UTF_8);
+                URIBuilder uriBuilder = new URIBuilder(new URI(id));
+                List<NameValuePair> params = uriBuilder.getQueryParams();
                 for (NameValuePair param : params) {
                     if (param.getName().equals("user")) {
                         result.put(VAL_USER, param.getValue());
@@ -113,10 +118,10 @@ public class CredentialResolver {
         return result;
     }
 
-    private HttpRequestBase buildRequestBase(String id, String vaultAddress) {
+    private ClassicHttpRequest buildRequestBase(String id, String vaultAddress) {
         if (id.contains(SSH_CERT_ISSUE_PATH)) {
-            HttpEntityEnclosingRequestBase post = new HttpPost(vaultAddress + "/v1/" + id);
-            post.setEntity(new StringEntity("{}", "UTF-8"));
+            HttpPost post = new HttpPost(vaultAddress + "/v1/" + id);
+            post.setEntity(new StringEntity("{}", StandardCharsets.UTF_8));
             return post;
         }
 
@@ -130,7 +135,7 @@ public class CredentialResolver {
         return "1.0";
     }
 
-    public static String send(HttpUriRequest req, String vaultCA, boolean tlsSkipVerify) throws IOException {
+    public static String send(ClassicHttpRequest req, String vaultCA, boolean tlsSkipVerify) throws IOException {
         SSLContext sslContext;
         try {
             TLSConfig tlsConfig = new TLSConfig().verify(!tlsSkipVerify);
@@ -144,13 +149,12 @@ public class CredentialResolver {
 
         CloseableHttpClient httpClient;
         if (sslContext != null) {
-            SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(
-                sslContext,
-                null,
-                null,
-                SSLConnectionSocketFactory.getDefaultHostnameVerifier());
-            httpClient = HttpClients.custom()
+            SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(sslContext);
+            HttpClientConnectionManager cm = PoolingHttpClientConnectionManagerBuilder.create()
                 .setSSLSocketFactory(sslsf)
+                .build();
+            httpClient = HttpClients.custom()
+                .setConnectionManager(cm)
                 .build();
         } else {
             httpClient = defaultHTTPClient;
@@ -165,9 +169,14 @@ public class CredentialResolver {
                 body = s.hasNext() ? s.next() : "";
             }
 
-            int status = response.getStatusLine().getStatusCode();
+            int status = response.getCode();
             if (status < 200 || status >= 300) {
-                String message = String.format("Failed to query Vault URL: %s.", req.getURI());
+                String message;
+                try {
+                    message = String.format("Failed to query Vault URL: %s.", req.getUri());
+                } catch (URISyntaxException e) {
+                    message = "Failed to query Vault URL.";
+                }
                 // Try to parse the error as a Vault error and extract relevant fields.
                 try {
                     VaultError json = gson.fromJson(body, VaultError.class);
@@ -186,7 +195,7 @@ public class CredentialResolver {
                     message += "\n\n" + body;
                 }
 
-                throw new HttpResponseException(status, message);
+                throw new IOException(message);
             }
         }
 

--- a/src/main/java/com/snc/discovery/CredentialResolver.java
+++ b/src/main/java/com/snc/discovery/CredentialResolver.java
@@ -8,6 +8,7 @@ package com.snc.discovery;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.service_now.mid.services.Config;
+import org.apache.hc.client5.http.HttpResponseException;
 import org.apache.hc.client5.http.classic.methods.*;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
@@ -16,7 +17,6 @@ import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuil
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
 import org.apache.hc.core5.http.ClassicHttpRequest;
-import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.net.URIBuilder;
@@ -195,7 +195,7 @@ public class CredentialResolver {
                     message += "\n\n" + body;
                 }
 
-                throw new IOException(message);
+                throw new HttpResponseException(status, message);
             }
         }
 


### PR DESCRIPTION
https://hashicorp.atlassian.net/browse/VAULT-42140
Got some help from [#team-prodsec-hc] and as per their suggestions removed all go binary related entries from security-scan.hcl
here is link where it was failing after merging into main.
https://github.com/hashicorp/crt-workflows-common/actions/runs/21369656064/job/61511007079
Apparently we are not supposed to have binary related as its a jar.